### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/Black-Thunder/ioBroker.melcloud"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.4.0",


### PR DESCRIPTION
Adapter core 3.x.x is know to fail to install on node 14 and earlier as npm 6 does not install peerDependencies.
So this adapter should require node 16 or newer to avoid problems.